### PR TITLE
Fix build

### DIFF
--- a/include/sf2cute/types.hpp
+++ b/include/sf2cute/types.hpp
@@ -401,16 +401,16 @@ struct SFVersionTag;
 struct SFVersionTag {
   /// Constructs a new zero-valued SFVersionTag.
   SFVersionTag() noexcept :
-      major(0),
-      minor(0) {
+      major_version(0),
+      minor_version(0) {
   };
 
   /// Constructs a new SFVersionTag using the specified version numbers.
-  /// @param major the major version number.
-  /// @param minor the minor version number.
-  SFVersionTag(uint16_t major, uint16_t minor) noexcept :
-      major(std::move(major)),
-      minor(std::move(minor)) {
+  /// @param major_version the major version number.
+  /// @param minor_version the minor version number.
+  SFVersionTag(uint16_t major_version, uint16_t minor_version) noexcept :
+      major_version(std::move(major_version)),
+      minor_version(std::move(minor_version)) {
   };
 
   /// Indicates a SFVersionTag object is "equal to" the other one.
@@ -420,7 +420,7 @@ struct SFVersionTag {
   friend inline bool operator==(
       const SFVersionTag & x,
       const SFVersionTag & y) noexcept {
-    return std::tie(x.major, x.minor) == std::tie(y.major, y.minor);
+    return std::tie(x.major_version, x.minor_version) == std::tie(y.major_version, y.minor_version);
   }
 
   /// Indicates a SFVersionTag object is "not equal to" the other one.
@@ -440,7 +440,7 @@ struct SFVersionTag {
   friend inline bool operator<(
       const SFVersionTag & x,
       const SFVersionTag & y) noexcept {
-    return std::tie(x.major, x.minor) < std::tie(y.major, y.minor);
+    return std::tie(x.major_version, x.minor_version) < std::tie(y.major_version, y.minor_version);
   }
 
   /// Indicates a SFVersionTag object is "less than or equal to" the other one.
@@ -486,15 +486,15 @@ struct SFVersionTag {
   /// @return a string representation of the version.
   inline std::string to_string() const {
     std::ostringstream string_builder;
-    string_builder << major << "." << minor;
+    string_builder << major_version << "." << minor_version;
     return string_builder.str();
   }
 
   /// Major version number.
-  uint16_t major;
+  uint16_t major_version;
 
   /// Minor version number.
-  uint16_t minor;
+  uint16_t minor_version;
 };
 
 } // namespace sf2cute
@@ -509,7 +509,7 @@ namespace std
     /// @param key the object to be hashed.
     /// @return the hash value.
     std::size_t operator()(sf2cute::SFVersionTag const & key) const noexcept {
-      return std::hash<uint32_t>()((static_cast<uint32_t>(key.major) << 16) + key.minor);
+      return std::hash<uint32_t>()((static_cast<uint32_t>(key.major_version) << 16) + key.minor_version);
     }
   };
 } // namespace std

--- a/src/sf2cute/file_writer.cpp
+++ b/src/sf2cute/file_writer.cpp
@@ -159,8 +159,8 @@ std::unique_ptr<RIFFChunkInterface> SoundFontWriter::MakePdtaListChunk() {
 /// Make a chunk with a version number.
 std::unique_ptr<RIFFChunkInterface> SoundFontWriter::MakeVersionChunk(std::string name, SFVersionTag version) {
   std::vector<char> data(4);
-  WriteInt16L(&data[0], version.major);
-  WriteInt16L(&data[2], version.minor);
+  WriteInt16L(&data[0], version.major_version);
+  WriteInt16L(&data[2], version.minor_version);
   return std::make_unique<RIFFChunk>(std::move(name), std::move(data));
 }
 

--- a/src/sf2cute/riff.cpp
+++ b/src/sf2cute/riff.cpp
@@ -75,7 +75,7 @@ RIFFChunk::size_type RIFFChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void RIFFChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 
@@ -112,7 +112,7 @@ void RIFFChunk::WriteHeader(std::ostream & out,
   }
 
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 
@@ -207,7 +207,7 @@ void RIFFListChunk::WriteHeader(std::ostream & out,
   }
 
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 
@@ -285,7 +285,7 @@ RIFF::size_type RIFF::size() const noexcept {
 /// Writes this RIFF to the specified output stream.
 void RIFF::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 
@@ -317,7 +317,7 @@ void RIFF::WriteHeader(std::ostream & out,
   }
 
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_ibag_chunk.cpp
+++ b/src/sf2cute/riff_ibag_chunk.cpp
@@ -79,7 +79,7 @@ SFRIFFIbagChunk::size_type SFRIFFIbagChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFIbagChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_igen_chunk.cpp
+++ b/src/sf2cute/riff_igen_chunk.cpp
@@ -96,7 +96,7 @@ SFRIFFIgenChunk::size_type SFRIFFIgenChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFIgenChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_imod_chunk.cpp
+++ b/src/sf2cute/riff_imod_chunk.cpp
@@ -79,7 +79,7 @@ SFRIFFImodChunk::size_type SFRIFFImodChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFImodChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_inst_chunk.cpp
+++ b/src/sf2cute/riff_inst_chunk.cpp
@@ -79,7 +79,7 @@ SFRIFFInstChunk::size_type SFRIFFInstChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFInstChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_pbag_chunk.cpp
+++ b/src/sf2cute/riff_pbag_chunk.cpp
@@ -79,7 +79,7 @@ SFRIFFPbagChunk::size_type SFRIFFPbagChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFPbagChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_pgen_chunk.cpp
+++ b/src/sf2cute/riff_pgen_chunk.cpp
@@ -96,7 +96,7 @@ SFRIFFPgenChunk::size_type SFRIFFPgenChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFPgenChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_phdr_chunk.cpp
+++ b/src/sf2cute/riff_phdr_chunk.cpp
@@ -78,7 +78,7 @@ SFRIFFPhdrChunk::size_type SFRIFFPhdrChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFPhdrChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_pmod_chunk.cpp
+++ b/src/sf2cute/riff_pmod_chunk.cpp
@@ -79,7 +79,7 @@ SFRIFFPmodChunk::size_type SFRIFFPmodChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFPmodChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_shdr_chunk.cpp
+++ b/src/sf2cute/riff_shdr_chunk.cpp
@@ -91,7 +91,7 @@ SFRIFFShdrChunk::size_type SFRIFFShdrChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFShdrChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 

--- a/src/sf2cute/riff_smpl_chunk.cpp
+++ b/src/sf2cute/riff_smpl_chunk.cpp
@@ -77,7 +77,7 @@ SFRIFFSmplChunk::size_type SFRIFFSmplChunk::size() const noexcept {
 /// Writes this chunk to the specified output stream.
 void SFRIFFSmplChunk::Write(std::ostream & out) const {
   // Save exception bits of output stream.
-  const int old_exception_bits = out.exceptions();
+  const std::ios_base::iostate old_exception_bits = out.exceptions();
   // Set exception bits to get output error as an exception.
   out.exceptions(std::ios::badbit | std::ios::failbit);
 


### PR DESCRIPTION
major and minor are conflict with macros defined in sys/sysmacros.h.
Cannot convert from int to iostate.