### PR TITLE
Improve CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,95 +1,147 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8.2)
 
-project(sf2cute C CXX)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(sf2cute
+    LANGUAGES C CXX
+    VERSION 0.2.0)
 
-set(VERSION "0.2.0")
+set(EXAMPLES_INSTALL_DIR "bin" CACHE "PATH" "Where to install the examples")
 
-include_directories(include)
+#============================================================================
+# sf2cute library
+#============================================================================
+add_library(sf2cute "")
 
-if(MSVC)
-    option(STATIC_CRT "Use static CRT libraries" OFF)
+target_sources(sf2cute
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/file.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/file_writer.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/generator_item.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/instrument.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/instrument_zone.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/modulator.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/modulator_key.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/modulator_item.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/preset.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/preset_zone.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_ibag_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_igen_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_imod_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_inst_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pbag_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pgen_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_phdr_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pmod_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_shdr_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_smpl_chunk.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/sample.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/zone.cpp
 
-    # Rewrite command line flags to use /MT if necessary
-    if(STATIC_CRT)
-        foreach(flag_var
-                CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-                CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${flag_var} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-            endif(${flag_var} MATCHES "/MD")
-        endforeach(flag_var)
-    endif()
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/byteio.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/file_writer.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_ibag_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_igen_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_imod_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_inst_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pbag_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pgen_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_phdr_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_pmod_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_shdr_chunk.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute/riff_smpl_chunk.hpp
+
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/modulator_item.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/preset.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/preset_zone.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/sample.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/types.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/version.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/zone.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/file.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/generator_item.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/instrument.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/instrument_zone.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/modulator.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/include/sf2cute/modulator_key.hpp
+)
+
+target_include_directories(sf2cute
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/src/sf2cute
+)
+
+set_target_properties(sf2cute PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+target_compile_features(sf2cute PUBLIC cxx_std_14)
+
+add_library(sf2cute::sf2cute ALIAS sf2cute)
+
+add_executable(write_sf2 "")
+
+target_sources(write_sf2
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/examples/write_sf2.cpp
+)
+target_link_libraries(write_sf2 PRIVATE sf2cute)
+
+#============================================================================
+# Install and Export sf2cute
+#============================================================================
+
+include(GNUInstallDirs)
+
+# install library files needed for linking
+install(
+    TARGETS sf2cute
+    EXPORT sf2cute-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# install the public header files
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# installs the *cmake files in share directory
+install(
+    EXPORT sf2cute-targets
+    FILE sf2cute-targets.cmake
+    NAMESPACE sf2cute::
+    DESTINATION share/sf2cute
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    ${CMAKE_BINARY_DIR}/cmake/sf2cute-config-version.cmake
+    VERSION ${SF2CUTE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/sf2cute-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/sf2cute-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sf2cute
+)
+
+install(
+    FILES
+        ${CMAKE_BINARY_DIR}/cmake/sf2cute-config.cmake
+        ${CMAKE_BINARY_DIR}/cmake/sf2cute-config-version.cmake
+    DESTINATION share/sf2cute
+)
+
+if(NOT DISABLE_INSTALL_EXAMPLES)
+    install(
+        TARGETS write_sf2
+        RUNTIME DESTINATION ${EXAMPLES_INSTALL_DIR}
+    )
 endif()
-
-
-#============================================================================
-# sf2cute
-#============================================================================
-
-set(SF2CUTE_PUBLIC_HDRS
-    include/sf2cute.hpp
-    include/sf2cute/modulator_item.hpp
-    include/sf2cute/preset.hpp
-    include/sf2cute/preset_zone.hpp
-    include/sf2cute/sample.hpp
-    include/sf2cute/types.hpp
-    include/sf2cute/version.hpp
-    include/sf2cute/zone.hpp
-    include/sf2cute/file.hpp
-    include/sf2cute/generator_item.hpp
-    include/sf2cute/instrument.hpp
-    include/sf2cute/instrument_zone.hpp
-    include/sf2cute/modulator.hpp
-    include/sf2cute/modulator_key.hpp
-)
-set(SF2CUTE_PRIVATE_HDRS
-    src/sf2cute/byteio.hpp
-    src/sf2cute/file_writer.hpp
-    src/sf2cute/riff.hpp
-    src/sf2cute/riff_ibag_chunk.hpp
-    src/sf2cute/riff_igen_chunk.hpp
-    src/sf2cute/riff_imod_chunk.hpp
-    src/sf2cute/riff_inst_chunk.hpp
-    src/sf2cute/riff_pbag_chunk.hpp
-    src/sf2cute/riff_pgen_chunk.hpp
-    src/sf2cute/riff_phdr_chunk.hpp
-    src/sf2cute/riff_pmod_chunk.hpp
-    src/sf2cute/riff_shdr_chunk.hpp
-    src/sf2cute/riff_smpl_chunk.hpp
-)
-set(SF2CUTE_SRCS
-    src/sf2cute/file.cpp
-    src/sf2cute/file_writer.cpp
-    src/sf2cute/generator_item.cpp
-    src/sf2cute/instrument.cpp
-    src/sf2cute/instrument_zone.cpp
-    src/sf2cute/modulator.cpp
-    src/sf2cute/modulator_key.cpp
-    src/sf2cute/modulator_item.cpp
-    src/sf2cute/preset.cpp
-    src/sf2cute/preset_zone.cpp
-    src/sf2cute/riff.cpp
-    src/sf2cute/riff_ibag_chunk.cpp
-    src/sf2cute/riff_igen_chunk.cpp
-    src/sf2cute/riff_imod_chunk.cpp
-    src/sf2cute/riff_inst_chunk.cpp
-    src/sf2cute/riff_pbag_chunk.cpp
-    src/sf2cute/riff_pgen_chunk.cpp
-    src/sf2cute/riff_phdr_chunk.cpp
-    src/sf2cute/riff_pmod_chunk.cpp
-    src/sf2cute/riff_shdr_chunk.cpp
-    src/sf2cute/riff_smpl_chunk.cpp
-    src/sf2cute/sample.cpp
-    src/sf2cute/zone.cpp
-)
-
-add_library(sf2cute STATIC ${SF2CUTE_SRCS} ${SF2CUTE_PUBLIC_HDRS} ${SF2CUTE_PRIVATE_HDRS})
-
-#============================================================================
-# Example binaries
-#============================================================================
-
-add_executable(write_sf2 examples/write_sf2.cpp)
-target_link_libraries(write_sf2 sf2cute)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(sf2cute
     LANGUAGES C CXX
     VERSION 0.2.0)
 
-set(EXAMPLES_INSTALL_DIR "bin" CACHE "PATH" "Where to install the examples")
+set(SF2CUTE_EXAMPLES_INSTALL_DIR "bin" CACHE "PATH" "Where to install the examples")
+option(SF2CUTE_INSTALL_EXAMPLES "Install example executables" ON)
 
 #============================================================================
 # sf2cute library
@@ -139,9 +140,9 @@ install(
     DESTINATION share/sf2cute
 )
 
-if(NOT DISABLE_INSTALL_EXAMPLES)
+if(SF2CUTE_INSTALL_EXAMPLES)
     install(
         TARGETS write_sf2
-        RUNTIME DESTINATION ${EXAMPLES_INSTALL_DIR}
+        RUNTIME DESTINATION ${SF2CUTE_EXAMPLES_INSTALL_DIR}
     )
 endif()

--- a/cmake/sf2cute-config.cmake.in
+++ b/cmake/sf2cute-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET sf2cute::sf2cute)
+    include(${CMAKE_CURRENT_LIST_DIR}/sf2cute-targets.cmake)
+endif()


### PR DESCRIPTION
At @REGoth-project we are on our way to create a [vcpkg](https://github.com/Microsoft/vcpkg) port for your library. Since your library already makes use of CMake, we figured we could improve it so that it uses modern conventions and style to make it easier to operator both from vcpkg and as standalone package.

Here is a brief summary of the changes:
- The generated library type is not hardcoded, so that if someone needs a shared library instead of a static one can just specify `-DBUILD_SHARED_LIBS=ON` when configuring
- The package exports proper CMake targets, which makes it easy to use from other CMake projects, as it only needs `find_package(sf2cute CONFIG REQUIRED)` now
- The example executable can be chosen to be installed or not