### PR TITLE
Fix installing when used as CMake submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ install(
 
 # install the public header files
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -122,7 +122,7 @@ install(
 include(CMakePackageConfigHelpers)
 
 write_basic_package_version_file(
-    ${CMAKE_BINARY_DIR}/cmake/sf2cute-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/sf2cute-config-version.cmake
     VERSION ${SF2CUTE_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
@@ -135,8 +135,8 @@ configure_package_config_file(
 
 install(
     FILES
-        ${CMAKE_BINARY_DIR}/cmake/sf2cute-config.cmake
-        ${CMAKE_BINARY_DIR}/cmake/sf2cute-config-version.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/sf2cute-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/sf2cute-config-version.cmake
     DESTINATION share/sf2cute
 )
 


### PR DESCRIPTION
Fixes installation/CPack on a project using sf2cute as a submodule by looking for files to install from the current project folder, instead of the top level folder (even though ideally headers and stuff shouldn't install in such a situation anyway but it's a start. Commit message describes this the other way round, oops).